### PR TITLE
Revert "Bump addressable from 2.7.0 to 2.8.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
+    addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.7)


### PR DESCRIPTION
Reverts mriceflame/mriceflame.github.io#3