### PR TITLE
Revert "Bump rexml from 3.2.4 to 3.2.5"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.2.4)
     rouge (3.25.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)


### PR DESCRIPTION
Reverts mriceflame/mriceflame.github.io#2